### PR TITLE
Refactor structure and some re-write of sections

### DIFF
--- a/integrations/deployment/appimage.rst
+++ b/integrations/deployment/appimage.rst
@@ -1,0 +1,32 @@
+AppImage
+________
+
+`AppImage <https://appimage.org/>`_ is a format for Linux portable applications. Its major advantages are:
+
+- It does not require root permissions.
+- It does not require to install any application (it uses :command:`chmod +x`).
+- It does not require the installation of runtime or a daemon into the system.
+
+AppImage uses filesystem in user-space 
+(`FUSE <https://github.com/libfuse/libfuse>`_).
+
+The main steps of the `packaging process <https://docs.appimage.org/packaging-guide/manual.html#>`__ are pretty straightforward 
+and could be easily automated:
+
+- Create a directory like ``MyApp.AppDir``
+- Download the `AppImage runtime <https://github.com/AppImage/AppImageKit/releases>`_ (**AppRun** file) and put it into the directory.
+- Copy all dependency files, like libraries (*.so*), resources (e.g. images) inside the directory.
+- Fill the *myapp.desktop* configuration file with some brief metadata of your application: name, category...
+- Run :command:`appimagetool`.
+
+The copy step can be automatically done with Conan using the :ref:`json generator<deployable_json_generator>` and a custom script or just using
+the :ref:`deploy generator <deployable_deploy_generator>`.
+
+The result of the previous steps will give you a *MyApp-x86_64.AppImage* file, which is a regular Linux ELF file:
+
+.. code-block:: console
+
+    $ file MyApp-x86_64.AppImage
+    MyApp-x86_64.AppImage: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/l, for GNU/Linux 2.6.18, stripped
+
+Finally, that file file could be easily distributed just by copying and uploading it to an FTP server, moving it to the flash drive, etc..

--- a/integrations/deployment/flatpak.rst
+++ b/integrations/deployment/flatpak.rst
@@ -1,0 +1,13 @@
+Flatpak
+_______
+
+`Flatpak <https://flatpak.org/>`_ is a package management system to distribute desktop applications for Linux. It is based on `OSTree <https://ostree.readthedocs.io/en/latest/manual/introduction/>`_.
+
+The `packaging process <http://docs.flatpak.org/en/latest/first-build.html>`__ is:
+
+- Install the flatpak runtime and SDK.
+- Create a manifest ``<app-id>.json``
+- Run the ``flatpak-builder`` in order to produce the application
+- `publish <http://docs.flatpak.org/en/latest/publishing.html>`__ the application for further distribution
+
+Alternatively, ``flatpak`` allows distributing the `single-file <http://docs.flatpak.org/en/latest/single-file-bundles.html>`_ package. Such package, however, cannot be run or installed on its own, it's needed to be imported to the local repository on another machine.

--- a/integrations/deployment/makeself.rst
+++ b/integrations/deployment/makeself.rst
@@ -1,0 +1,18 @@
+Makeself
+--------
+
+`Makeself <https://makeself.io>`_ is a small command-line utility to generate self-extracting archives for Unix. It is pretty popular and it
+is used by `VirtualBox <https://www.virtualbox.org/wiki/Linux_Downloads>`_ and `CMake <https://cmake.org/download/>`_ projects.
+
+Makeself creates archives that are just small startup scripts (*.run*, *.bin* or *.sh*) concatenated with tarballs.
+
+When you run such self-extracting archive:
+
+- A small script (shim) extracts the embedded archive into the temporary directory
+- Script passes the execution to the entry point within the unpacked archive
+- application is being run
+- The temporary directory removed
+
+Therefore, it transparently appears just like a normal application execution. 
+Check out the `guide <http://xmodulo.com/how-to-create-a-self-extracting-archive-or-installer-in-linux.html>`_ on how to make
+self-extracting archive with Makeself.

--- a/integrations/deployment/others.rst
+++ b/integrations/deployment/others.rst
@@ -1,0 +1,5 @@
+Others
+______
+
+There are enterprise solutions for deployment that re recommended to be used for production environments, such as 
+`ansible <https://www.ansible.com/>`_, `chef <https://www.chef.io/application-deployment/>`_ or `puppet <https://puppet.com/>`_.

--- a/integrations/deployment/snap.rst
+++ b/integrations/deployment/snap.rst
@@ -1,0 +1,14 @@
+Snap
+____
+
+`Snap <https://snapcraft.io/>`_ is the package management system available for the wide range of Linux distributions.
+Unlike AppImage, Snap requires a daemon installed in the system in order to operate. Under the hood, **Snap** is based on
+`SquashFS <https://github.com/plougher/squashfs-tools>`_.
+
+The `packaging process <https://snapcraft.io/docs/creating-a-snap>`__ could be summed up in the following steps:
+
+- `Install <https://snapcraft.io/docs/snapcraft-overview>`_ the snapcraft
+- Run ``snapcraft init``
+- Edit the ``snap/snapcraft.yml`` `manifest <https://snapcraft.io/docs/snapcraft-format>`_
+- Run ``snapcraft`` in order to produce the snap
+- `Publish <https://forum.snapcraft.io/t/releasing-your-app/6795>`__ and upload snap, so it could be installed on other systems.

--- a/integrations/deployment/system_package_manager.rst
+++ b/integrations/deployment/system_package_manager.rst
@@ -1,0 +1,13 @@
+System package manager
+______________________
+
+The Conan packages can be deployed using a system package manager. Usually this process is done by creating a folder structure with the
+needed files and bundling all of them into the file format specific to the system package manager of choice, like *.rpm* or *.deb*. This
+method is very convenient for deployment and distribution as it is natively integrated in the system. However, there are some limitations:
+
+- It might require to create a specific package for each of supported distro, or at least use the lowest version (see concerns about
+  ``glibc`` below), see the section :ref:`custom_settings`, which explains how to customize Conan settings to model different Linux
+  distributions in order to create different packages for them.
+
+- If you want to target different distros, then you need to create one package per supported distro (likely one for
+  `Ubuntu <https://ubuntu.com/>`_, one for `Arch Linux <https://www.archlinux.org/>`_, etc.), and formats or guidelines for each distro might differ significantly


### PR DESCRIPTION
I have split the sections on integration/deployment into small chapters and re-wrote some of them. I think this structure is more aligned with the structure of the docs.

In general, those sections **should** to be improved providing a little bit more background for each tool and real steps or explanation to show users the real way of **integration**. Otherwise, those sections will be useless.

Regarding the integration/deployment/others section, I don't think it makes sense to name just other tools for deployment without providing a common way to integrate with Conan. I that integration does not exist, just don't name it.

- Please have a look at it and remove or add new information.

--------------------------------------

I have also moved the deployment challenges to de integration section. I think it fits better there although I think it is not its place. This way, the "running packages" section is reduced and the content makes sense.

- However, **there are some explanations missing** like why you can link statically the C++ library but not the C one, why you can link statically to the runtime without issues, what is the solution to the System API calls...

-------------

Finally, please go through all the texts and review the explanation. Avoid repeating the same words, give clear examples and provide context for future explanations. Also, make sure that the tone is appropriate for each part of the documentation (writing a section in the reference is not the same as writing a how-to).